### PR TITLE
got delete test to run & resolved time issue in create view

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -57,8 +57,11 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+        except Payment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
-            return HttpResponseServerError(ex)
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
 
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single payment type

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -1,3 +1,4 @@
+from bangazonapi.models.payment import Payment
 import datetime
 import json
 from rest_framework import status
@@ -15,8 +16,16 @@ class PaymentTests(APITestCase):
         response = self.client.post(url, data, format='json')
         json_response = json.loads(response.content)
         self.token = json_response["token"]
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        payment = Payment()
+        payment.merchant_name = "American Express"
+        payment.account_number = "111-1111-1111"
+        payment.expiration_date = "2024-12-31"
+        payment.create_date = datetime.date.today()
+        payment.customer_id = 1
+        payment.save()
 
     def test_create_payment_type(self):
         """
@@ -40,4 +49,10 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment(self):
+
+        response = self.client.delete(f'/paymenttypes/1')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.client.get(f"/paymenttypes/1")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed the request.data to have the accurate data: `create_date` and `expiration_date` in `paymenttype.py` view
- Made sure the correct HTTP response was in the `retrieve` in the `paymenttype.py` view
-Added a test_delete function in the `payments.py` test
-Added a payment type object in the `setup` 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

## Request
Do a POST method with `http://localhost:8000/paymenttypes`

```
json
 {
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2024-03-01",
        "create_date": "2021-09-02",
        "customer_id": 7
    }
```
## Response 201 Created

```
json
{
    "id": 4,
    "url": "http://localhost:8000/paymenttypes/4",
    "merchant_name": "Visa",
    "account_number": "fj0398fjw0g89434",
    "expiration_date": "2024-03-01",
    "create_date": "2021-09-02",
    "customer_id": 7
}
```



## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] check and see if code that was changed is present in both the `paymenttype.py` view and `payments.py` test modules
- [ ] run `python3 manage.py test tests -v 1`
- [ ] make sure all tested as successful 
- [ ] open postman
- [ ] run request with example code above
- [ ] check and see if response matches


## Related Issues

- Fixes #9 
- Fixes #19 