### PR TITLE
Changed it to greater than equal to

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -272,7 +272,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- changed logic of list in `product.py` view, there is not item that has been sold 20 items or more

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `http://localhost:8000/products?number_sold=1` Gets purchased number items equal to or greater than 1


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 45,
        "name": "Corvette",
        "price": 795.8,
        "number_sold": 1,
        "description": "1987 Chevrolet",
        "quantity": 2,
        "created_date": "2019-10-07",
        "location": "Ueno",
        "image_path": null,
        "average_rating": null,
        "category_id": 2
    },
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 1.0,
        "category_id": 2
    }
]
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] check code for changes mentioned above
- [ ] run postman `http://localhost:8000/products?number_sold=1`
- [ ] check and see if response is similar to example code above


## Related Issues

- Fixes #21 